### PR TITLE
pragma warning push and pop for clang also

### DIFF
--- a/include/amp-sims/cabs.hpp
+++ b/include/amp-sims/cabs.hpp
@@ -1,6 +1,12 @@
 #pragma once
 #pragma warning(disable : 4458)
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
+
+
 #include "effect.hpp"
 #include <cstdlib>
 
@@ -1977,3 +1983,7 @@ class Cabs final : public Effect<T>
 };
 } // namespace airwindohhs::cabs
 #pragma warning(default : 4458)
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/include/biquads/biquad2.hpp
+++ b/include/biquads/biquad2.hpp
@@ -1,6 +1,11 @@
 #pragma once
 #pragma warning(disable : 4458)
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
+
 #include "effect.hpp"
 #include <cstdlib>
 
@@ -521,3 +526,6 @@ class Biquad2 final : public Effect<T>
 } // namespace airwindohhs::biquad2
 #pragma warning(default : 4458)
 
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/include/dynamics/surge.hpp
+++ b/include/dynamics/surge.hpp
@@ -1,6 +1,11 @@
 #pragma once
 #pragma warning(disable : 4458)
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
+
 #include "effect.hpp"
 #include <cstdlib>
 
@@ -257,3 +262,7 @@ class Surge final : public Effect<T>
 };
 } // namespace airwindohhs::surge
 #pragma warning(default : 4458)
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/include/lo-fi/pockey.hpp
+++ b/include/lo-fi/pockey.hpp
@@ -1,6 +1,11 @@
 #pragma once
 #pragma warning(disable : 4458)
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
+
 #include "effect.hpp"
 #include <cstdlib>
 
@@ -352,3 +357,7 @@ class Pockey final : public Effect<T>
 };
 } // namespace airwindohhs::pockey
 #pragma warning(default : 4458)
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/include/reverb/pocketverbs.hpp
+++ b/include/reverb/pocketverbs.hpp
@@ -1,6 +1,11 @@
 #pragma once
 #pragma warning(disable : 4458)
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
+
 #include "effect.hpp"
 #include <cstdlib>
 
@@ -12431,3 +12436,7 @@ class PocketVerbs final : public Effect<T>
 };
 } // namespace airwindohhs::pocketverbs
 #pragma warning(default : 4458)
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif

--- a/include/utility/monitoring3.hpp
+++ b/include/utility/monitoring3.hpp
@@ -1,6 +1,11 @@
 #pragma once
 #pragma warning(disable : 4458)
 
+#if defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshadow"
+#endif
+
 #include "effect.hpp"
 #include <cstdlib>
 
@@ -1352,3 +1357,7 @@ class Monitoring3 final : public Effect<T>
 };
 } // namespace airwindohhs::monitoring3
 #pragma warning(default : 4458)
+
+#if defined(__clang__)
+#pragma clang diagnostic pop
+#endif


### PR DESCRIPTION
okay... so when i ignored the C4458 warning, i only did it for windows. now it works on macOS as well